### PR TITLE
added balenaFin Dockerfile

### DIFF
--- a/Dockerfile.fincm3
+++ b/Dockerfile.fincm3
@@ -1,0 +1,11 @@
+# Dockerfile for balenaFin 1.0 & 1.1
+
+FROM wlisac/generic-armv7ahf-swift:5.0
+
+WORKDIR /app
+
+COPY . ./
+
+RUN swift build
+
+CMD ["./.build/debug/Hello"]


### PR DESCRIPTION
Since [balenaFin](https://www.balena.io/fin/) is `armv7`-based, simply copying the `armv7ahf` version of the `Dockerfile` for it will allow `balena push <Swift app>` to work on that architecture as well. 

This is a bit friendlier (and less head scratching) for anyone working on that hardware platform. The default version of this project fails out when attempting to send to non-Pi hardware. 